### PR TITLE
Fix issue with tee parameter

### DIFF
--- a/cmd/lgo/install/main.go
+++ b/cmd/lgo/install/main.go
@@ -32,7 +32,7 @@ func recordStderr(lgopath string) error {
 	if err != nil {
 		return err
 	}
-	tee := exec.Command("tee", "--ignore-interrupts", logPath)
+	tee := exec.Command("tee", "-i", logPath)
 	tee.Stdout = os.Stderr
 	tee.Stderr = os.Stderr
 	tee.Stdin = r


### PR DESCRIPTION
In a few distributions, for example, Alpine Linux, tee doesn't support `--ignore-interrupts` because, it looks like, it is not standard (it is not supported in macOS neither, for example). The correct option is `-i`.