### PR TITLE
Fixing #8 - code completion does not work after `go` and `defer`. 

### DIFF
--- a/converter/complete.go
+++ b/converter/complete.go
@@ -248,7 +248,7 @@ func listCandidatesFromScope(s *types.Scope, pos token.Pos, prefix string, candi
 		return
 	}
 	for _, name := range s.Names() {
-		if !strings.HasPrefix(name, prefix) {
+		if !strings.HasPrefix(strings.ToLower(name), prefix) {
 			continue
 		}
 		if _, obj := s.LookupParent(name, pos); obj != nil {
@@ -305,7 +305,19 @@ func Complete(src string, pos token.Pos, conf *Config) ([]string, int, int) {
 	return match, start, end
 }
 
+func removePrefixes(src, prefix string) string {
+	if strings.Index(src, prefix) >= 0 {
+		src = strings.Replace(src, prefix, "", 1)
+	}
+
+	return src
+}
+
 func complete(src string, pos token.Pos, conf *Config) ([]string, int, int) {
+	// Removing go and defer prefixes from the string; fixes #8
+	removePrefixes(src, "go ")
+	removePrefixes(src, "defer ")
+
 	fset, blk, _ := parseLesserGoString(src)
 
 	target := completeTargetFromAST(src, pos, blk)

--- a/converter/complete_test.go
+++ b/converter/complete_test.go
@@ -406,6 +406,30 @@ var q Q = p
 			ignoreWant:  true,
 			wantInclude: []string{"int64"},
 		},
+		{
+			name: "test_name_at_camel_hump",
+			src: `
+			func testFunc() {
+			}
+			testf[cur]`,
+			want: []string{"testFunc"},
+		},
+		{
+			name: "test_name_with_go_keyword",
+			src: `
+			func testFunc() {
+			}
+			go testF[cur]`,
+			want: []string{"testFunc"},
+		},
+		{
+			name: "test_name_with_defer_keyword",
+			src: `
+			func testFunc() {
+			}
+			defer testF[cur]`,
+			want: []string{"testFunc"},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Fixing #8 - code completion does not work after `go` and `defer`. 

Also, fixing a bug - when the input's length is greater than the first capital letter's position of the suggestion. For example, if the input is testF and expected suggestion is TestFunc, it failed to suggest anything.