### PR TITLE
Fix for #58 - Adding support for loading startup files

### DIFF
--- a/jupyter/gojupyterscaffold/gojupyterscaffold.go
+++ b/jupyter/gojupyterscaffold/gojupyterscaffold.go
@@ -222,3 +222,8 @@ func (s *Server) Loop() {
 
 	// TODO: Support stdin.
 }
+
+func (s *Server) ExecuteScript(src string) {
+	req := &message{Content: &ExecuteRequest{Code: src}}
+	s.execQueue.queue <- &executeQueueItem{req, s.shell}
+}


### PR DESCRIPTION
Loading startup files from ~/.jupyter/startup folder in sorted order. Any go file present in the folder will be loaded. Files should not have a package statement at the beginning of the file though.